### PR TITLE
5: 채용공고 목록 조회 API

### DIFF
--- a/src/main/java/wanted/preonboarding/backend/controller/RecruitController.java
+++ b/src/main/java/wanted/preonboarding/backend/controller/RecruitController.java
@@ -18,11 +18,10 @@ public class RecruitController {
     private final RecruitService recruitService;
 
     @GetMapping
-    public ArrayList<RecruitPosting> getAllPosting(){
-        ArrayList<RecruitPosting> postingArrayList = recruitService.getAllPosting();
+    public ArrayList<RecruitPosting> getAllPosting(@RequestParam(name = "search", required = false)String keyword){
+        ArrayList<RecruitPosting> postingArrayList = recruitService.getAllPosting(keyword);
         return postingArrayList;
     }
-
     @PostMapping
     public ResponseEntity<Map<String,String>> createPosting(@RequestBody RecruitPostingDto recruitPostingDto){
         recruitService.createPosting(recruitPostingDto);

--- a/src/main/java/wanted/preonboarding/backend/controller/RecruitController.java
+++ b/src/main/java/wanted/preonboarding/backend/controller/RecruitController.java
@@ -5,8 +5,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import wanted.preonboarding.backend.dto.RecruitPostingDto;
+import wanted.preonboarding.backend.entity.RecruitPosting;
 import wanted.preonboarding.backend.service.RecruitService;
 
+import java.util.ArrayList;
 import java.util.Map;
 
 @RestController
@@ -14,6 +16,12 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class RecruitController {
     private final RecruitService recruitService;
+
+    @GetMapping
+    public ArrayList<RecruitPosting> getAllPosting(){
+        ArrayList<RecruitPosting> postingArrayList = recruitService.getAllPosting();
+        return postingArrayList;
+    }
 
     @PostMapping
     public ResponseEntity<Map<String,String>> createPosting(@RequestBody RecruitPostingDto recruitPostingDto){

--- a/src/main/java/wanted/preonboarding/backend/controller/RecruitController.java
+++ b/src/main/java/wanted/preonboarding/backend/controller/RecruitController.java
@@ -4,8 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import wanted.preonboarding.backend.dto.PostListResponseDto;
 import wanted.preonboarding.backend.dto.RecruitPostingDto;
-import wanted.preonboarding.backend.entity.RecruitPosting;
 import wanted.preonboarding.backend.service.RecruitService;
 
 import java.util.ArrayList;
@@ -18,8 +18,8 @@ public class RecruitController {
     private final RecruitService recruitService;
 
     @GetMapping
-    public ArrayList<RecruitPosting> getAllPosting(@RequestParam(name = "search", required = false)String keyword){
-        ArrayList<RecruitPosting> postingArrayList = recruitService.getAllPosting(keyword);
+    public ArrayList<PostListResponseDto> getAllPosting(@RequestParam(name = "search", required = false)String keyword){
+        ArrayList<PostListResponseDto> postingArrayList = recruitService.getAllPosting(keyword);
         return postingArrayList;
     }
     @PostMapping
@@ -27,7 +27,6 @@ public class RecruitController {
         recruitService.createPosting(recruitPostingDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("message", "공고를 성공적으로 등록했습니다."));
     }
-
     @PutMapping("/{postId}")
     public ResponseEntity<Map<String,String>> updatePosting(@PathVariable Long postId,
                                                             @RequestBody RecruitPostingDto recruitPostingDto){

--- a/src/main/java/wanted/preonboarding/backend/dto/PostListResponseDto.java
+++ b/src/main/java/wanted/preonboarding/backend/dto/PostListResponseDto.java
@@ -1,0 +1,14 @@
+package wanted.preonboarding.backend.dto;
+
+import lombok.Data;
+
+@Data
+public class PostListResponseDto {
+    private Long postId;
+    private String companyName;
+    private String nation;
+    private String region;
+    private String position;
+    private int reward;
+    private String skill;
+}

--- a/src/main/java/wanted/preonboarding/backend/entity/Company.java
+++ b/src/main/java/wanted/preonboarding/backend/entity/Company.java
@@ -11,7 +11,7 @@ import lombok.Data;
 public class Company {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
+    private Long id;
     private String name;
     private String country;
     private String region;

--- a/src/main/java/wanted/preonboarding/backend/entity/RecruitPosting.java
+++ b/src/main/java/wanted/preonboarding/backend/entity/RecruitPosting.java
@@ -8,7 +8,7 @@ import lombok.Data;
 public class RecruitPosting {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long id;
+    private Long id;
     @ManyToOne
     @JoinColumn(name="company_id")
     private Company company;

--- a/src/main/java/wanted/preonboarding/backend/repository/RecruitRepository.java
+++ b/src/main/java/wanted/preonboarding/backend/repository/RecruitRepository.java
@@ -2,10 +2,10 @@ package wanted.preonboarding.backend.repository;
 
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 import wanted.preonboarding.backend.entity.RecruitPosting;
 
 @Repository
-public interface RecruitRepository extends JpaRepository<RecruitPosting, Long> {
-
+public interface RecruitRepository extends JpaRepository<RecruitPosting, Long>, JpaSpecificationExecutor<RecruitPosting> {
 }

--- a/src/main/java/wanted/preonboarding/backend/searcher/SearchBuilder.java
+++ b/src/main/java/wanted/preonboarding/backend/searcher/SearchBuilder.java
@@ -1,0 +1,83 @@
+package wanted.preonboarding.backend.searcher;
+
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * JPA Specification 쿼리 생성기
+ * 참조1:
+ * https://www.baeldung.com/rest-api-search-language-spring-data-specifications
+ * 참조2:
+ */
+public class SearchBuilder<T> {
+	private final List<SearchCriteria> params;
+
+	public SearchBuilder() {
+		this.params = new ArrayList<>();
+	}
+
+	public SearchBuilder<T> with(String dataField, SearchOperationType operation, List<Object> values) {
+		this.params.add(new SearchCriteria(dataField, operation, values, false));
+		return this;
+	}
+
+	public SearchBuilder<T> isNull(String dataField) {
+		isNull(dataField, false);
+		return this;
+	}
+
+	public SearchBuilder<T> isNull(String dataField, boolean isOrOperation) {
+		this.params.add(new SearchCriteria(dataField, SearchOperationType.NULL, null, isOrOperation));
+		return this;
+	}
+
+	public SearchBuilder<T> isNotNull(String dataField) {
+		isNotNull(dataField, false);
+		return this;
+	}
+
+	public SearchBuilder<T> isNotNull(String dataField, boolean isOrOperation) {
+		this.params.add(new SearchCriteria(dataField, SearchOperationType.NOT_NULL, null, isOrOperation));
+		return this;
+	}
+
+	public SearchBuilder<T> with(String dataField, SearchOperationType operation, List<Object> values,
+			boolean isOrOperation) {
+		this.params.add(new SearchCriteria(dataField, operation, values, isOrOperation));
+		return this;
+	}
+
+	public SearchBuilder<T> with(String dataField, SearchOperationType operation, Object value) {
+		this.params.add(new SearchCriteria(dataField, operation, List.of(value), false));
+		return this;
+	}
+
+	public SearchBuilder<T> with(String dataField, SearchOperationType operation, Object value,
+			boolean isOrOperation) {
+		this.params.add(new SearchCriteria(dataField, operation, List.of(value), isOrOperation));
+		return this;
+	}
+
+	public static <T> SearchBuilder<T> builder() {
+		return new SearchBuilder<T>();
+	}
+
+	public Specification<T> build() {
+		if (params.size() == 0) {
+			return null;
+		}
+
+		List<Specification<T>> specs = params.stream().map(SearchSpecification<T>::new).collect(Collectors.toList());
+
+		Specification<T> result = specs.get(0);
+
+		for (int i = 1; i < params.size(); i++) {
+			result = params.get(i).isOrOperation() ? Specification.where(result).or(specs.get(i))
+					: Specification.where(result).and(specs.get(i));
+		}
+		return result;
+	}
+}

--- a/src/main/java/wanted/preonboarding/backend/searcher/SearchCriteria.java
+++ b/src/main/java/wanted/preonboarding/backend/searcher/SearchCriteria.java
@@ -1,0 +1,21 @@
+package wanted.preonboarding.backend.searcher;
+
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public class SearchCriteria {
+
+    public SearchCriteria(String dataField, SearchOperationType operation, List<Object> values, boolean isOrOperation) {
+        this.dataField = dataField;
+        this.operation = operation;
+        this.values = values;
+        this.isOrOperation = isOrOperation;
+    }
+
+    private String dataField;
+    private SearchOperationType operation;
+    private List<Object> values;
+    private boolean isOrOperation;
+}

--- a/src/main/java/wanted/preonboarding/backend/searcher/SearchOperationType.java
+++ b/src/main/java/wanted/preonboarding/backend/searcher/SearchOperationType.java
@@ -1,0 +1,22 @@
+package wanted.preonboarding.backend.searcher;
+
+public enum SearchOperationType {
+
+    CONTAINS,
+    CONTAINS_IGNORE_CASE,
+    START_WITH,
+    START_WITH_IGNORE_CASE,
+    END_WITH,
+    END_WITH_IGNORE_CASE,
+    NULL,
+    NOT_NULL,
+    EQUAL,
+    NOT_EQUAL,
+    LESS_THAN,
+    LESS_THAN_OR_EQUAL,
+    GREATER_THAN,
+    GREATER_THAN_OR_EQUAL,
+    IN,
+    NOT_IN,
+    BETWEEN
+}

--- a/src/main/java/wanted/preonboarding/backend/searcher/SearchSpecification.java
+++ b/src/main/java/wanted/preonboarding/backend/searcher/SearchSpecification.java
@@ -1,0 +1,74 @@
+package wanted.preonboarding.backend.searcher;
+
+import jakarta.persistence.criteria.*;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.List;
+
+public class SearchSpecification<T> implements Specification<T> {
+
+    private SearchCriteria criteria;
+
+    public SearchSpecification(final SearchCriteria searchCriteria) {
+        super();
+        this.criteria = searchCriteria;
+    }
+
+    @SuppressWarnings({ "unchecked", "rawtypes" })
+    @Override
+    public Predicate toPredicate(Root<T> root, CriteriaQuery<?> query, CriteriaBuilder builder) {
+        String[] fields = criteria.getDataField().split("\\.");
+        Path<?> path = root.get(fields[0]);
+
+        // Join 처리
+        Join<?, ?> join = null;
+        if (fields.length > 1) {
+            for (int i = 0; i < fields.length - 1; i++) {
+                join = (join == null) ? root.join(fields[i]) : join.join(fields[i]);
+            }
+            path = join.get(fields[fields.length - 1]);
+        }
+
+        Object arg = criteria.getValues().stream().findFirst().orElse(null);
+
+        switch (criteria.getOperation()) {
+            case NULL:
+                return builder.isNull(path);
+            case NOT_NULL:
+                return builder.isNotNull(path);
+            case EQUAL:
+                return builder.equal(path, arg);
+            case NOT_EQUAL:
+                return builder.notEqual(path, arg);
+            case GREATER_THAN:
+                return builder.greaterThan((Path<Comparable>) path, (Comparable) arg);
+            case GREATER_THAN_OR_EQUAL:
+                return builder.greaterThanOrEqualTo((Path<Comparable>) path, (Comparable) arg);
+            case LESS_THAN:
+                return builder.lessThan((Path<Comparable>) path, (Comparable) arg);
+            case LESS_THAN_OR_EQUAL:
+                return builder.lessThanOrEqualTo((Path<Comparable>) path, (Comparable) arg);
+            case CONTAINS:
+                return builder.like(path.as(String.class), "%" + arg.toString() + "%");
+            case CONTAINS_IGNORE_CASE:
+                return builder.like(builder.upper(path.as(String.class)), "%" + arg.toString().toUpperCase() + "%");
+            case START_WITH:
+                return builder.like(path.as(String.class), arg.toString() + "%");
+            case START_WITH_IGNORE_CASE:
+                return builder.like(builder.upper(path.as(String.class)), arg.toString().toUpperCase() + "%");
+            case END_WITH:
+                return builder.like(path.as(String.class), "%" + arg.toString());
+            case END_WITH_IGNORE_CASE:
+                return builder.like(builder.upper(path.as(String.class)), "%" + arg.toString().toUpperCase());
+            case IN:
+                return path.in(criteria.getValues());
+            case NOT_IN:
+                return builder.not(path.in(criteria.getValues()));
+            case BETWEEN:
+                List<Object> values = criteria.getValues();
+                return builder.between((Path<Comparable>) path, (Comparable) values.get(0), (Comparable) values.get(1));
+            default:
+                return null;
+        }
+    }
+}

--- a/src/main/java/wanted/preonboarding/backend/service/RecruitService.java
+++ b/src/main/java/wanted/preonboarding/backend/service/RecruitService.java
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import wanted.preonboarding.backend.dto.PostListResponseDto;
 import wanted.preonboarding.backend.dto.RecruitPostingDto;
 import wanted.preonboarding.backend.entity.Company;
 import wanted.preonboarding.backend.entity.RecruitPosting;
@@ -12,6 +13,7 @@ import wanted.preonboarding.backend.repository.RecruitRepository;
 import wanted.preonboarding.backend.searcher.SearchBuilder;
 import wanted.preonboarding.backend.searcher.SearchOperationType;
 import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -24,13 +26,27 @@ public class RecruitService {
                 .orElseThrow(() -> new EntityNotFoundException("등록된 공고가 없습니다."));
     }
 
-    public ArrayList<RecruitPosting> getAllPosting(String keyword){
+    public ArrayList<PostListResponseDto> getAllPosting(String keyword){
         SearchBuilder<RecruitPosting> searchBuilder = SearchBuilder.builder();
         if (keyword != null && !keyword.isEmpty()) {
             searchBuilder.with("skill", SearchOperationType.CONTAINS, keyword, true);
             searchBuilder.with("company.name", SearchOperationType.CONTAINS, keyword, true);
         }
-        return new ArrayList<>(recruitRepository.findAll(searchBuilder.build()));
+
+        List<RecruitPosting> recruitPostings = recruitRepository.findAll(searchBuilder.build());
+        ArrayList<PostListResponseDto> postList = new ArrayList<>();
+        for (RecruitPosting post : recruitPostings) {
+            PostListResponseDto dto = new PostListResponseDto();
+            dto.setPostId(post.getId());
+            dto.setCompanyName(post.getCompany().getName());
+            dto.setNation(post.getCompany().getCountry());
+            dto.setRegion(post.getCompany().getRegion());
+            dto.setPosition(post.getPosition());
+            dto.setReward(post.getReward());
+            dto.setSkill(post.getSkill());
+            postList.add(dto);
+        }
+        return postList;
     }
 
     @Transactional

--- a/src/main/java/wanted/preonboarding/backend/service/RecruitService.java
+++ b/src/main/java/wanted/preonboarding/backend/service/RecruitService.java
@@ -9,6 +9,8 @@ import wanted.preonboarding.backend.entity.Company;
 import wanted.preonboarding.backend.entity.RecruitPosting;
 import wanted.preonboarding.backend.repository.CompanyRepository;
 import wanted.preonboarding.backend.repository.RecruitRepository;
+import wanted.preonboarding.backend.searcher.SearchBuilder;
+import wanted.preonboarding.backend.searcher.SearchOperationType;
 import java.util.ArrayList;
 
 @Service
@@ -22,8 +24,13 @@ public class RecruitService {
                 .orElseThrow(() -> new EntityNotFoundException("등록된 공고가 없습니다."));
     }
 
-    public ArrayList<RecruitPosting> getAllPosting(){
-        return new ArrayList<>(recruitRepository.findAll());
+    public ArrayList<RecruitPosting> getAllPosting(String keyword){
+        SearchBuilder<RecruitPosting> searchBuilder = SearchBuilder.builder();
+        if (keyword != null && !keyword.isEmpty()) {
+            searchBuilder.with("skill", SearchOperationType.CONTAINS, keyword, true);
+            searchBuilder.with("company.name", SearchOperationType.CONTAINS, keyword, true);
+        }
+        return new ArrayList<>(recruitRepository.findAll(searchBuilder.build()));
     }
 
     @Transactional

--- a/src/main/java/wanted/preonboarding/backend/service/RecruitService.java
+++ b/src/main/java/wanted/preonboarding/backend/service/RecruitService.java
@@ -9,6 +9,7 @@ import wanted.preonboarding.backend.entity.Company;
 import wanted.preonboarding.backend.entity.RecruitPosting;
 import wanted.preonboarding.backend.repository.CompanyRepository;
 import wanted.preonboarding.backend.repository.RecruitRepository;
+import java.util.ArrayList;
 
 @Service
 @RequiredArgsConstructor
@@ -19,6 +20,10 @@ public class RecruitService {
     public RecruitPosting getRecruitPosting(Long postId){
         return recruitRepository.findById(postId)
                 .orElseThrow(() -> new EntityNotFoundException("등록된 공고가 없습니다."));
+    }
+
+    public ArrayList<RecruitPosting> getAllPosting(){
+        return new ArrayList<>(recruitRepository.findAll());
     }
 
     @Transactional


### PR DESCRIPTION
1. 채용공고 목록 조회 API추가
- 전체 목록 조회 가능  
- RequestParam(name="search") 사용 시
  - 사용기술 또는 회사명이 포함된 공고 검색 가능(영어 대소문자 구분X)
- ResponseDTO추가